### PR TITLE
Fixed: white color on yellow background (h1)

### DIFF
--- a/module2.js
+++ b/module2.js
@@ -48,6 +48,11 @@
     for (j = 0; j < rainbow.length; j++) {
       choosedColor = rainbow[Math.floor(7 * Math.random())];
     }
+    if (choosedColor == 'yellow') {// white text on yellow bg not readable
+      document.querySelector('.titleH1').style.color = '#000';
+    } else {
+      document.querySelector('.titleH1').style.color = '#fff';
+    }
     // custom event
     const event = new CustomEvent("sentence-choosed-color-changed", {
       detail: {
@@ -60,7 +65,7 @@
     // checking if condition is true
     if (
       choosedSentence ===
-        "Life is like a box of chocolates. You never know what you’re going to get. Forrest Gump" &&
+      "Life is like a box of chocolates. You never know what you’re going to get. Forrest Gump" &&
       choosedColor === "green"
     ) {
       condition = true;


### PR DESCRIPTION
Little fix to H1 text, which is been white on yellow background (pretty hard to read).
Now, if background-color: yellow , h1 text will be black.
![image](https://user-images.githubusercontent.com/25365923/201492509-75c4a283-6c9e-488d-b157-d3ed05930a26.png)
